### PR TITLE
Don't override global sys.sydout/stderr

### DIFF
--- a/model/clients/google/maps_cli.py
+++ b/model/clients/google/maps_cli.py
@@ -11,8 +11,8 @@ import codecs
 
 from config import GoogleMapsAPIKeys
 
-sys.stdout = codecs.getwriter('utf8')(sys.stdout)
-sys.stderr = codecs.getreader('utf8')(sys.stderr)
+stdout = codecs.getwriter('utf8')(sys.stdout)
+stderr = codecs.getreader('utf8')(sys.stderr)
 
 
 # Methods


### PR DESCRIPTION
Create local stdout and stderr with encoding wrapper, and use it in place of sys.stdout/sys.stderr in the module